### PR TITLE
fix: checkbox component custom class

### DIFF
--- a/packages/qwik-storefront-ui/src/components/SfCheckbox/SfCheckbox.tsx
+++ b/packages/qwik-storefront-ui/src/components/SfCheckbox/SfCheckbox.tsx
@@ -7,7 +7,9 @@ export const SfCheckbox = component$<SfCheckboxProps>(
       {...(ref ? { ref } : {})}
       class={[
         'h-[18px] min-w-[18px] border-2 rounded-sm appearance-none cursor-pointer text-gray-500 enabled:hover:border-primary-800 enabled:active:border-primary-900 enabled:hover:checked:text-primary-800 enabled:hover:indeterminate:text-primary-800 enabled:active:checked:text-primary-900 enabled:checked:text-primary-700 checked:bg-checked-checkbox-current border-current indeterminate:bg-indeterminate-checkbox-current enabled:indeterminate:text-primary-700 disabled:text-gray-300 hover:text-gray-300 disabled:cursor-not-allowed enabled:focus-visible:outline enabled:focus-visible:outline-offset',
-        'border-negative-700 enabled:hover:border-negative-800 enabled:active:border-negative-900',
+        invalid
+          ? 'border-negative-700 enabled:hover:border-negative-800 enabled:active:border-negative-900'
+          : '',
         _class,
       ]}
       type="checkbox"

--- a/packages/qwik-storefront-ui/src/components/SfCheckbox/SfCheckbox.tsx
+++ b/packages/qwik-storefront-ui/src/components/SfCheckbox/SfCheckbox.tsx
@@ -5,13 +5,11 @@ export const SfCheckbox = component$<SfCheckboxProps>(
   ({ invalid, class: _class, ref, onChange$, ...attributes }) => (
     <input
       {...(ref ? { ref } : {})}
-      class={{
-        'h-[18px] min-w-[18px] border-2 rounded-sm appearance-none cursor-pointer text-gray-500 enabled:hover:border-primary-800 enabled:active:border-primary-900 enabled:hover:checked:text-primary-800 enabled:hover:indeterminate:text-primary-800 enabled:active:checked:text-primary-900 enabled:checked:text-primary-700 checked:bg-checked-checkbox-current border-current indeterminate:bg-indeterminate-checkbox-current enabled:indeterminate:text-primary-700 disabled:text-gray-300 hover:text-gray-300 disabled:cursor-not-allowed enabled:focus-visible:outline enabled:focus-visible:outline-offset':
-          true,
-        'border-negative-700 enabled:hover:border-negative-800 enabled:active:border-negative-900':
-          invalid,
-        _class: true,
-      }}
+      class={[
+        'h-[18px] min-w-[18px] border-2 rounded-sm appearance-none cursor-pointer text-gray-500 enabled:hover:border-primary-800 enabled:active:border-primary-900 enabled:hover:checked:text-primary-800 enabled:hover:indeterminate:text-primary-800 enabled:active:checked:text-primary-900 enabled:checked:text-primary-700 checked:bg-checked-checkbox-current border-current indeterminate:bg-indeterminate-checkbox-current enabled:indeterminate:text-primary-700 disabled:text-gray-300 hover:text-gray-300 disabled:cursor-not-allowed enabled:focus-visible:outline enabled:focus-visible:outline-offset',
+        'border-negative-700 enabled:hover:border-negative-800 enabled:active:border-negative-900',
+        _class,
+      ]}
       type="checkbox"
       data-testid="checkbox"
       onChange$={onChange$}


### PR DESCRIPTION
# What is it?

- [x] Bug
# Description

In this scenario the custom class `example` wasn't applied:

```ts
<SfCheckbox value="value" class="example" />
```

# why
After destructuring and renaming `_class`:

```ts
  ({ invalid, class: _class, ref, onChange$, ...attributes }) => (
```

it was applied in the wrong way using `_class` as key of the object:

```ts
class={{
  'A': true,
  'B': invalid,
  _class: true,
}}
```

The result was:

```html
<element class="A B _class">
```

Now, the fix applies classes by using array syntax_

```ts
class={[
  'A',
  'B',
  _class,
]}
```

result:
```html
<element class="A B example"
```

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-storefront-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
