### PR TITLE
fix: add type to SfButton/Button attributes

### DIFF
--- a/packages/qwik-storefront-ui/src/components/SfButton/SfButton.tsx
+++ b/packages/qwik-storefront-ui/src/components/SfButton/SfButton.tsx
@@ -1,4 +1,4 @@
-import { Slot, component$ } from '@builder.io/qwik';
+import { Slot, component$, PropsOf } from '@builder.io/qwik';
 import { SfButtonProps, SfButtonSize, SfButtonVariant } from './types';
 
 export const defaultButtonTag = 'button';
@@ -29,7 +29,7 @@ export const getSizeClasses = (
   }
 };
 
-const Button = component$((attributes) => {
+const Button = component$((attributes: PropsOf<'button'>) => {
   return (
     <button {...attributes}>
       <Slot />


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement

# Description

Add type to Button's attribute, used internally in SfButton Component

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-storefront-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
