### PR TITLE
fix: sfCheckBox imports in barrel file

### DIFF
--- a/packages/qwik-storefront-ui/src/components/SfCheckbox/index.ts
+++ b/packages/qwik-storefront-ui/src/components/SfCheckbox/index.ts
@@ -1,3 +1,1 @@
-export * from './types';
-
-export { SfCheckbox } from './SfCheckbox';
+export { SfCheckbox, type SfCheckboxProps } from './SfCheckbox';


### PR DESCRIPTION
# What is it?

- [x] Bug

# Description

I have removed the reference of previous external types to avoid build errors

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-storefront-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
