### PR TITLE
fix: sfChip square

### DIFF
--- a/packages/qwik-storefront-ui/src/components/SfCheckbox/index.ts
+++ b/packages/qwik-storefront-ui/src/components/SfCheckbox/index.ts
@@ -1,3 +1,1 @@
-export * from './types';
-
-export { SfCheckbox } from './SfCheckbox';
+export { SfCheckbox, type SfCheckboxProps } from './SfCheckbox';

--- a/packages/qwik-storefront-ui/src/components/SfCheckbox/index.ts
+++ b/packages/qwik-storefront-ui/src/components/SfCheckbox/index.ts
@@ -1,1 +1,0 @@
-export { SfCheckbox, type SfCheckboxProps } from './SfCheckbox';

--- a/packages/qwik-storefront-ui/src/components/SfChip/SfChip.tsx
+++ b/packages/qwik-storefront-ui/src/components/SfChip/SfChip.tsx
@@ -23,11 +23,11 @@ export const SfChip = component$<SfChipProps>(
       switch (size) {
         case SfChipSize.sm:
           return square
-            ? 'px-1.5'
+            ? 'px-1.5 rounded-none'
             : [slotPrefix ? 'pl-1.5' : 'pl-3', slotSuffix ? 'pr-1.5' : 'pr-3'];
         default:
           return square
-            ? 'px-2'
+            ? 'px-2 rounded-none'
             : [slotPrefix ? 'pl-2' : 'pl-4', slotSuffix ? 'pr-2' : 'pr-4'];
       }
     };


### PR DESCRIPTION
# What is it?

- [x] Bug
- [ ] Docs / tests
- [ ] Other

# Description

Square property was not applied

```
 <SfChip size="sm" square>
```


# Screenshots/Demo

Previous:

![image](https://github.com/qwikifiers/qwik-storefront-ui/assets/1772083/424367e1-307f-46e8-af43-01030cfacc52)

Current:
![image](https://github.com/qwikifiers/qwik-storefront-ui/assets/1772083/e856c484-26c1-45fb-802b-0c97fd72251a)

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/qwik-storefront-ui/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
